### PR TITLE
Add Go example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,54 +2,101 @@
 
 A few crude benchmarks for Elixir, Golang, C++, and Ruby
 
-    Processor Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
-    OS: Ubuntu 16.04
+    Processor: 2.5 GHz Quad-Core Intel Core i7
+    Memory: 16 GB 1600 MHz DDR3
+    OS: macOS 10.15.3
 
 ## 10mb.json
 
-### Golang [jq]
+### CPP
 
-    $ time jq '.' data/10mb.json > /dev/null
-    real    0m0.567s
-    user    0m0.551s
-    sys     0m0.016s
+    $ time _builds/rapidjson-sax < ../../data/10mb.json
 
+    real	0m0.031s
+    user	0m0.026s
+    sys	    0m0.003s
+
+    $ time _builds/rapidjson-structure < ../../data/10mb.json
+
+    real	0m0.039s
+    user	0m0.032s
+    sys 	0m0.006s
+
+### Golang
+
+Notes:
+- Decoding to generic `map[string]interface{}` rather than specific (faster) struct.
+- Crude stream implementation requires top-level JSON object (not array)
+
+
+    $ time ./naive < ../data/10mb.json
+
+    real	0m0.386s
+    user	0m0.408s
+    sys	    0m0.060s
+
+    $  time ./streamed < ../data/10mb.json
+
+    real	0m0.182s
+    user	0m0.196s
+    sys	    0m0.020s
 
 ### Elixir
 
-    Time taken [Poison]: 1218.831ms
-    Time taken [Jason]: 508.461ms
+    Time taken [Poison]: 857.349ms
+    Time taken [Jason]: 438.837ms
 
 ### Ruby
 
-    time ruby app.rb
+    $ time ruby app.rb
 
-    real    0m0.220s
-    user    0m0.203s
-    sys     0m0.017s
+    real	0m0.299s
+    user	0m0.254s
+    sys	0m0.039s
 
 ## 100mb.json (https://github.com/zemirco/sf-city-lots-json/blob/master/citylots.json)
 
-### Golang [jq]
+### CPP
 
-    $ time jq '.' data/citylots.json > /dev/null
+    $ time _builds/rapidjson-sax < ../../data/citylots.json
 
-    real    0m14.436s
-    user    0m13.992s
-    sys     0m0.420s
+    real	0m0.463s
+    user	0m0.435s
+    sys	    0m0.026s
+
+    $ time _builds/rapidjson-structure < ../../data/citylots.json
+
+    real	0m0.719s
+    user	0m0.602s
+    sys	    0m0.117s
+
+### Golang
+
+    $ time ./naive < ../data/citylots.json
+
+    real	0m7.613s
+    user	0m9.015s
+    sys	    0m0.693s
+
+    $  time ./streamed < ../data/citylots.json
+
+    real	0m4.448s
+    user	0m5.558s
+    sys	    0m0.420s
 
 ## Elixir
 
-      Time taken [Poison]: 32_640.87ms
-      Time taken [Jason]: 11_602.128ms
+    Time taken [Poison]: 30483.717ms
+    Time taken [Jason]: 12806.43ms
 
 ## Ruby
 
-      $ time ruby app.rb
+    $ time ruby app.rb
 
-      real    0m4.738s
-      user    0m4.498s
-      sys     0m0.240s
+    real	0m6.352s
+    user	0m5.977s
+    sys	    0m0.360s
+
 
 
 # Building instructions:
@@ -62,3 +109,10 @@ Just run the `build.sh` script from within the `cpp/rapidjson` directory and it 
 
 To run it the C++ programs will accept it via stdin, so don't pass it in as an argument, but instead pipe it into to it like via `time _builds/rapidjson-structure < ../../data/citylots.json` or so.
 
+## Go
+
+`go build naive.go ; go build streamed.go`
+
+## Elixir
+
+`mix test`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Notes:
 - Decoding to generic `map[string]interface{}` rather than specific (faster) struct.
 - Crude stream implementation requires top-level JSON object (not array)
 
+>
 
     $ time ./naive < ../data/10mb.json
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ A few crude benchmarks for Elixir, Golang, C++, and Ruby
 
     real	0m0.031s
     user	0m0.026s
-    sys	    0m0.003s
+    sys	0m0.003s
 
     $ time _builds/rapidjson-structure < ../../data/10mb.json
 
     real	0m0.039s
     user	0m0.032s
-    sys 	0m0.006s
+    sys	0m0.006s
 
 ### Golang
 
@@ -34,13 +34,13 @@ Notes:
 
     real	0m0.386s
     user	0m0.408s
-    sys	    0m0.060s
+    sys	0m0.060s
 
     $  time ./streamed < ../data/10mb.json
 
     real	0m0.182s
     user	0m0.196s
-    sys	    0m0.020s
+    sys	0m0.020s
 
 ### Elixir
 
@@ -63,13 +63,13 @@ Notes:
 
     real	0m0.463s
     user	0m0.435s
-    sys	    0m0.026s
+    sys	0m0.026s
 
     $ time _builds/rapidjson-structure < ../../data/citylots.json
 
     real	0m0.719s
     user	0m0.602s
-    sys	    0m0.117s
+    sys	0m0.117s
 
 ### Golang
 
@@ -77,13 +77,13 @@ Notes:
 
     real	0m7.613s
     user	0m9.015s
-    sys	    0m0.693s
+    sys	0m0.693s
 
     $  time ./streamed < ../data/citylots.json
 
     real	0m4.448s
     user	0m5.558s
-    sys	    0m0.420s
+    sys	0m0.420s
 
 ## Elixir
 
@@ -96,7 +96,7 @@ Notes:
 
     real	0m6.352s
     user	0m5.977s
-    sys	    0m0.360s
+    sys	0m0.360s
 
 
 

--- a/cpp/rapidjson/sax.cpp
+++ b/cpp/rapidjson/sax.cpp
@@ -7,7 +7,7 @@ using namespace rapidjson;
 struct Handler : public BaseReaderHandler<UTF8<>, Handler> {};
 
 int main(int argc, char *argv[]) {
-	GenericReader<UTF8<>, UTF8<>> reader;
+	GenericReader<UTF8<>, UTF8<> > reader;
 	char readBuffer[65536];
 	FileReadStream is(stdin, readBuffer, sizeof(readBuffer));
 	Handler handler;

--- a/go/naive.go
+++ b/go/naive.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var output []rune
+
+	for {
+		input, _, err := reader.ReadRune()
+		if err != nil && err == io.EOF {
+			break
+		}
+		output = append(output, input)
+	}
+
+	var result map[string]interface{}
+	json.Unmarshal([]byte(string(output)), &result)
+}

--- a/go/streamed.go
+++ b/go/streamed.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"log"
+	"os"
+)
+
+func main() {
+	dec := json.NewDecoder(bufio.NewReader(os.Stdin))
+
+	// read open bracket
+	// _, err := dec.Token()
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+
+	// while the array contains values
+	for dec.More() {
+		// var m Message
+		var result map[string]interface{}
+		// decode an array value (Message)
+		err := dec.Decode(&result)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// fmt.Printf("%s\n", result)
+	}
+
+	// read closing bracket
+	// _, err = dec.Token()
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+
+}


### PR DESCRIPTION
`jq` apparently isn't written in Go, so these are basic Go JSON examples with the standard lib. 